### PR TITLE
bqiface: add a testing package for bigquery

### DIFF
--- a/bigquery/bqiface/adapters.go
+++ b/bigquery/bqiface/adapters.go
@@ -1,0 +1,292 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bqiface
+
+import (
+	"cloud.google.com/go/bigquery"
+	"golang.org/x/net/context"
+)
+
+func AdaptClient(c *bigquery.Client) Client {
+	return client{c}
+}
+
+type (
+	client          struct{ *bigquery.Client }
+	copier          struct{ *bigquery.Copier }
+	dataset         struct{ *bigquery.Dataset }
+	datasetIterator struct{ *bigquery.DatasetIterator }
+	extractor       struct{ *bigquery.Extractor }
+	job             struct{ *bigquery.Job }
+	jobIterator     struct{ *bigquery.JobIterator }
+	loader          struct{ *bigquery.Loader }
+	query           struct{ *bigquery.Query }
+	rowIterator     struct{ *bigquery.RowIterator }
+	table           struct{ *bigquery.Table }
+	tableIterator   struct{ *bigquery.TableIterator }
+	uploader        struct{ *bigquery.Uploader }
+)
+
+func (client) embedToIncludeNewMethods()          {}
+func (copier) embedToIncludeNewMethods()          {}
+func (dataset) embedToIncludeNewMethods()         {}
+func (extractor) embedToIncludeNewMethods()       {}
+func (job) embedToIncludeNewMethods()             {}
+func (jobIterator) embedToIncludeNewMethods()     {}
+func (loader) embedToIncludeNewMethods()          {}
+func (query) embedToIncludeNewMethods()           {}
+func (rowIterator) embedToIncludeNewMethods()     {}
+func (table) embedToIncludeNewMethods()           {}
+func (datasetIterator) embedToIncludeNewMethods() {}
+func (tableIterator) embedToIncludeNewMethods()   {}
+func (uploader) embedToIncludeNewMethods()        {}
+
+func (c client) Location() string                     { return c.Client.Location }
+func (c client) SetLocation(s string)                 { c.Client.Location = s }
+func (c client) Close() error                         { return c.Client.Close() }
+func (c client) Dataset(id string) Dataset            { return dataset{c.Client.Dataset(id)} }
+func (c client) Jobs(ctx context.Context) JobIterator { return jobIterator{c.Client.Jobs(ctx)} }
+
+func (c client) DatasetInProject(p, d string) Dataset {
+	return dataset{c.Client.DatasetInProject(p, d)}
+}
+
+func (c client) Datasets(ctx context.Context) DatasetIterator {
+	return datasetIterator{c.Client.Datasets(ctx)}
+}
+
+func (c client) DatasetsInProject(ctx context.Context, p string) DatasetIterator {
+	return datasetIterator{c.Client.DatasetsInProject(ctx, p)}
+}
+
+func (c client) JobFromID(ctx context.Context, id string) (Job, error) {
+	return adaptJob(c.Client.JobFromID(ctx, id))
+}
+
+func (c client) JobFromIDLocation(ctx context.Context, id, location string) (Job, error) {
+	return adaptJob(c.Client.JobFromIDLocation(ctx, id, location))
+}
+
+func (c copier) JobIDConfig() *bigquery.JobIDConfig { return &c.Copier.JobIDConfig }
+
+func (c copier) SetCopyConfig(cc CopyConfig) {
+	c.Copier.CopyConfig = cc.CopyConfig
+	for _, t := range cc.Srcs {
+		c.Copier.CopyConfig.Srcs = append(c.Copier.CopyConfig.Srcs, t.(table).Table)
+	}
+	c.Copier.CopyConfig.Dst = cc.Dst.(table).Table
+}
+
+func (c copier) Run(ctx context.Context) (Job, error) {
+	return adaptJob(c.Copier.Run(ctx))
+}
+
+func (d dataset) ProjectID() string                { return d.Dataset.ProjectID }
+func (d dataset) DatasetID() string                { return d.Dataset.DatasetID }
+func (d dataset) Delete(ctx context.Context) error { return d.Dataset.Delete(ctx) }
+func (d dataset) DeleteWithContents(ctx context.Context) error {
+	return d.Dataset.DeleteWithContents(ctx)
+}
+func (d dataset) Table(id string) Table { return table{d.Dataset.Table(id)} }
+func (d dataset) Tables(ctx context.Context) TableIterator {
+	return tableIterator{d.Dataset.Tables(ctx)}
+}
+
+func (d dataset) Create(ctx context.Context, dm *DatasetMetadata) error {
+	return d.Dataset.Create(ctx, dm.toBQ())
+}
+
+func (d dataset) Metadata(ctx context.Context) (*DatasetMetadata, error) {
+	m, err := d.Dataset.Metadata(ctx)
+	return datasetMetadataFromBQ(m), err
+}
+
+func (d dataset) Update(ctx context.Context, dm DatasetMetadataToUpdate, etag string) (*DatasetMetadata, error) {
+	m, err := d.Dataset.Update(ctx, dm.toBQ(), etag)
+	if err != nil {
+		return nil, err
+	}
+	return datasetMetadataFromBQ(m), nil
+}
+
+func (di datasetIterator) SetListHidden(b bool)  { di.DatasetIterator.ListHidden = b }
+func (di datasetIterator) SetFilter(s string)    { di.DatasetIterator.Filter = s }
+func (di datasetIterator) SetProjectID(s string) { di.DatasetIterator.ProjectID = s }
+
+func (di datasetIterator) Next() (Dataset, error) {
+	ds, err := di.DatasetIterator.Next()
+	if err != nil {
+		return nil, err
+	}
+	return dataset{ds}, nil
+}
+
+func (e extractor) JobIDConfig() *bigquery.JobIDConfig { return &e.Extractor.JobIDConfig }
+
+func (e extractor) SetExtractConfig(c ExtractConfig) {
+	e.Extractor.ExtractConfig = c.ExtractConfig
+	e.Extractor.ExtractConfig.Src = c.Src.(table).Table
+}
+
+func (e extractor) Run(ctx context.Context) (Job, error) {
+	return adaptJob(e.Extractor.Run(ctx))
+}
+
+func (j job) Status(ctx context.Context) (*bigquery.JobStatus, error) { return j.Job.Status(ctx) }
+func (j job) LastStatus() *bigquery.JobStatus                         { return j.Job.LastStatus() }
+func (j job) Cancel(ctx context.Context) error                        { return j.Job.Cancel(ctx) }
+func (j job) Wait(ctx context.Context) (*bigquery.JobStatus, error)   { return j.Job.Wait(ctx) }
+
+func (j job) Read(ctx context.Context) (RowIterator, error) {
+	r, err := j.Job.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return rowIterator{r}, nil
+}
+
+func (j jobIterator) SetProjectID(s string)     { j.JobIterator.ProjectID = s }
+func (j jobIterator) SetAllUsers(b bool)        { j.JobIterator.AllUsers = b }
+func (j jobIterator) SetState(s bigquery.State) { j.JobIterator.State = s }
+
+func (j jobIterator) Next() (Job, error) {
+	return adaptJob(j.JobIterator.Next())
+}
+
+func (l loader) JobIDConfig() *bigquery.JobIDConfig { return &l.Loader.JobIDConfig }
+
+func (l loader) SetLoadConfig(c LoadConfig) {
+	l.Loader.LoadConfig = c.LoadConfig
+	l.Loader.LoadConfig.Dst = c.Dst.(table).Table
+}
+
+func (l loader) Run(ctx context.Context) (Job, error) {
+	return adaptJob(l.Loader.Run(ctx))
+}
+
+func (r rowIterator) SetStartIndex(i uint64)     { r.RowIterator.StartIndex = i }
+func (r rowIterator) Schema() bigquery.Schema    { return r.RowIterator.Schema }
+func (r rowIterator) TotalRows() uint64          { return r.RowIterator.TotalRows }
+func (r rowIterator) Next(dst interface{}) error { return r.RowIterator.Next(dst) }
+
+func (t table) ProjectID() string                    { return t.Table.ProjectID }
+func (t table) DatasetID() string                    { return t.Table.DatasetID }
+func (t table) TableID() string                      { return t.Table.TableID }
+func (t table) FullyQualifiedName() string           { return t.Table.FullyQualifiedName() }
+func (t table) Delete(ctx context.Context) error     { return t.Table.Delete(ctx) }
+func (t table) Uploader() Uploader                   { return uploader{t.Table.Uploader()} }
+func (t table) Read(ctx context.Context) RowIterator { return rowIterator{t.Table.Read(ctx)} }
+
+func (t table) Create(ctx context.Context, tm *bigquery.TableMetadata) error {
+	return t.Table.Create(ctx, tm)
+}
+func (t table) Metadata(ctx context.Context) (*bigquery.TableMetadata, error) {
+	return t.Table.Metadata(ctx)
+}
+
+func (t table) Update(ctx context.Context, tm bigquery.TableMetadataToUpdate, etag string) (*bigquery.TableMetadata, error) {
+	return t.Table.Update(ctx, tm, etag)
+}
+
+func (t table) CopierFrom(ts ...Table) Copier {
+	var bts []*bigquery.Table
+	for _, tb := range ts {
+		bts = append(bts, tb.(table).Table)
+	}
+	c := t.Table.CopierFrom(bts...)
+	return copier{c}
+}
+
+func (t table) ExtractorTo(dst *bigquery.GCSReference) Extractor {
+	return extractor{t.Table.ExtractorTo(dst)}
+}
+
+func (t table) LoaderFrom(s bigquery.LoadSource) Loader {
+	return loader{t.Table.LoaderFrom(s)}
+}
+
+func (ti tableIterator) Next() (Table, error) {
+	t, err := ti.TableIterator.Next()
+	if err != nil {
+		return nil, err
+	}
+	return table{t}, nil
+}
+
+func (u uploader) SetSkipInvalidRows(b bool)                    { u.Uploader.SkipInvalidRows = b }
+func (u uploader) SetIgnoreUnknownValues(b bool)                { u.Uploader.IgnoreUnknownValues = b }
+func (u uploader) SetTableTemplateSuffix(s string)              { u.Uploader.TableTemplateSuffix = s }
+func (u uploader) Put(ctx context.Context, i interface{}) error { return u.Uploader.Put(ctx, i) }
+
+func adaptJob(j *bigquery.Job, err error) (Job, error) {
+	if err != nil {
+		return nil, err
+	}
+	return job{j}, nil
+}
+
+func (m *DatasetMetadata) toBQ() *bigquery.DatasetMetadata {
+	m.DatasetMetadata.Access = accessEntriesToBQ(m.Access)
+	return &m.DatasetMetadata
+}
+
+func datasetMetadataFromBQ(m *bigquery.DatasetMetadata) *DatasetMetadata {
+	if m == nil {
+		return nil
+	}
+	return &DatasetMetadata{
+		DatasetMetadata: *m,
+		Access:          accessEntriesFromBQ(m.Access),
+	}
+}
+
+func (u DatasetMetadataToUpdate) toBQ() bigquery.DatasetMetadataToUpdate {
+	u.DatasetMetadataToUpdate.Access = accessEntriesToBQ(u.Access)
+	return u.DatasetMetadataToUpdate
+}
+
+func (e *AccessEntry) toBQ() *bigquery.AccessEntry {
+	if e.View != nil {
+		e.AccessEntry.View = e.View.(table).Table
+	}
+	return &e.AccessEntry
+}
+
+func accessEntryFromBQ(e *bigquery.AccessEntry) *AccessEntry {
+	if e == nil {
+		return nil
+	}
+	r := &AccessEntry{AccessEntry: *e}
+	if e.View != nil {
+		r.View = table{e.View}
+	}
+	return r
+}
+
+func accessEntriesToBQ(a []*AccessEntry) []*bigquery.AccessEntry {
+	var r []*bigquery.AccessEntry
+	for _, e := range a {
+		r = append(r, e.toBQ())
+	}
+	return r
+}
+
+func accessEntriesFromBQ(a []*bigquery.AccessEntry) []*AccessEntry {
+	var r []*AccessEntry
+	for _, e := range a {
+		r = append(r, accessEntryFromBQ(e))
+	}
+	return r
+}

--- a/bigquery/bqiface/bqiface_test.go
+++ b/bigquery/bqiface/bqiface_test.go
@@ -1,0 +1,137 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bqiface
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"google.golang.org/api/iterator"
+)
+
+func TestIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration tests skipped in short mode")
+	}
+	projectID := os.Getenv("BQIFACE_PROJECT")
+	if projectID == "" {
+		t.Skip("missing BQIFACE_PROJECT environment variable")
+	}
+
+	ctx := context.Background()
+	c, err := bigquery.NewClient(ctx, projectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := AdaptClient(c)
+	defer client.Close()
+
+	ds := client.Dataset(fmt.Sprintf("bqiface_%d", time.Now().Unix()))
+	var md DatasetMetadata
+	md.DefaultTableExpiration = time.Hour
+	var ae AccessEntry
+	ae.Role = bigquery.OwnerRole
+	ae.EntityType = bigquery.SpecialGroupEntity
+	ae.Entity = "projectOwners"
+	md.Access = []*AccessEntry{&ae}
+	err = ds.Create(ctx, &md)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	md2, err := ds.Metadata(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := md2.DefaultTableExpiration, md.DefaultTableExpiration; got != want {
+		t.Errorf("DefaultTableExpiration: got %s, want %s", got, want)
+	}
+	if got, want := len(md2.Access), 1; got != want {
+		t.Fatalf("got %d access entries, want %d", got, want)
+	}
+	if got, want := *md2.Access[0], ae; got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+
+	table := ds.Table("t")
+	schema := bigquery.Schema{
+		{Name: "name", Type: bigquery.StringFieldType},
+		{Name: "score", Type: bigquery.IntegerFieldType},
+	}
+	if err := table.Create(ctx, &bigquery.TableMetadata{Schema: schema}); err != nil {
+		t.Fatal(err)
+	}
+	upl := table.Uploader()
+	var saverRows []*bigquery.ValuesSaver
+
+	for i, name := range []string{"a", "b", "c"} {
+		saverRows = append(saverRows, &bigquery.ValuesSaver{
+			Schema:   schema,
+			InsertID: name,
+			Row:      []bigquery.Value{name, i},
+		})
+	}
+	if err := upl.Put(ctx, saverRows); err != nil {
+		t.Fatal(putError(err))
+	}
+	count := 0
+loop:
+	for {
+		it := table.Read(ctx)
+		for {
+			var v []bigquery.Value
+			err := it.Next(&v)
+			if err == iterator.Done {
+				if count == 0 {
+					// Wait for rows to appear; it may take a few seconds.
+					time.Sleep(1 * time.Second)
+					continue loop
+				}
+				break loop
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			count++
+		}
+	}
+	if got, want := count, len(saverRows); got != want {
+		t.Errorf("got %d rows, want %d", got, want)
+	}
+
+	if err := table.Delete(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := ds.Delete(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func putError(err error) string {
+	pme, ok := err.(bigquery.PutMultiError)
+	if !ok {
+		return err.Error()
+	}
+	var msgs []string
+	for _, err := range pme {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "\n")
+}

--- a/bigquery/bqiface/examples_test.go
+++ b/bigquery/bqiface/examples_test.go
@@ -1,0 +1,37 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bqiface_test
+
+import (
+	"cloud.google.com/go/bigquery"
+	"github.com/GoogleCloudPlatform/google-cloud-go-testing/bigquery/bqiface"
+	"golang.org/x/net/context"
+)
+
+func Example_AdaptClient() {
+	ctx := context.Background()
+	c, err := bigquery.NewClient(ctx, "my-project")
+	if err != nil {
+		// TODO: Handle error.
+	}
+	client := bqiface.AdaptClient(c)
+	defer client.Close()
+	ds := client.Dataset("my_dataset")
+	md, err := ds.Metadata(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	_ = md // TODO: use md.
+}

--- a/bigquery/bqiface/interfaces.go
+++ b/bigquery/bqiface/interfaces.go
@@ -1,0 +1,176 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bqiface provides a set of interfaces for the types in cloud.google.com/go/bigquery.
+// These can be used to create mocks or other test doubles.
+// The package also provides adapters to enable the types of the bigquery package to
+// implement these interfaces.
+//
+// We do not recommend using mocks for most testing. Please read
+// https://testing.googleblog.com/2013/05/testing-on-toilet-dont-overuse-mocks.html.
+//
+// You must embed these interfaces to implement them:
+//
+//    type ClientMock struct {
+//        bqiface.Client
+//        ...
+//    }
+//
+// This ensures that your implementations will not break when methods are added to the interfaces.
+package bqiface
+
+import (
+	"cloud.google.com/go/bigquery"
+	"golang.org/x/net/context"
+	"google.golang.org/api/iterator"
+)
+
+type Client interface {
+	Location() string
+	SetLocation(string)
+	Close() error
+	Dataset(string) Dataset
+	DatasetInProject(string, string) Dataset
+	Datasets(context.Context) DatasetIterator
+	DatasetsInProject(context.Context, string) DatasetIterator
+	JobFromID(context.Context, string) (Job, error)
+	JobFromIDLocation(context.Context, string, string) (Job, error)
+	Jobs(context.Context) JobIterator
+
+	embedToIncludeNewMethods()
+}
+
+type Copier interface {
+	JobIDConfig() *bigquery.JobIDConfig
+	SetCopyConfig(CopyConfig)
+	Run(context.Context) (Job, error)
+
+	embedToIncludeNewMethods()
+}
+
+type Dataset interface {
+	ProjectID() string
+	DatasetID() string
+	Create(context.Context, *DatasetMetadata) error
+	Delete(context.Context) error
+	DeleteWithContents(context.Context) error
+	Metadata(context.Context) (*DatasetMetadata, error)
+	Update(context.Context, DatasetMetadataToUpdate, string) (*DatasetMetadata, error)
+	Table(string) Table
+	Tables(context.Context) TableIterator
+
+	embedToIncludeNewMethods()
+}
+
+type DatasetIterator interface {
+	SetListHidden(bool)
+	SetFilter(string)
+	SetProjectID(string)
+	Next() (Dataset, error)
+	PageInfo() *iterator.PageInfo
+
+	embedToIncludeNewMethods()
+}
+
+type Extractor interface {
+	JobIDConfig() *bigquery.JobIDConfig
+	SetExtractConfig(ExtractConfig)
+	Run(context.Context) (Job, error)
+
+	embedToIncludeNewMethods()
+}
+
+type Loader interface {
+	JobIDConfig() *bigquery.JobIDConfig
+	SetLoadConfig(LoadConfig)
+	Run(context.Context) (Job, error)
+
+	embedToIncludeNewMethods()
+}
+
+type Job interface {
+	ID() string
+	Location() string
+	Config() (bigquery.JobConfig, error)
+	Status(context.Context) (*bigquery.JobStatus, error)
+	LastStatus() *bigquery.JobStatus
+	Cancel(context.Context) error
+	Wait(context.Context) (*bigquery.JobStatus, error)
+	Read(context.Context) (RowIterator, error)
+
+	embedToIncludeNewMethods()
+}
+
+type JobIterator interface {
+	SetProjectID(string)
+	SetAllUsers(bool)
+	SetState(bigquery.State)
+	Next() (Job, error)
+	PageInfo() *iterator.PageInfo
+
+	embedToIncludeNewMethods()
+}
+
+type Query interface {
+	JobIDConfig() *bigquery.JobIDConfig
+	SetqueryConfig(QueryConfig)
+	Run(context.Context) (Job, error)
+	Read(context.Context) (RowIterator, error)
+
+	embedToIncludeNewMethods()
+}
+
+type RowIterator interface {
+	SetStartIndex(uint64)
+	Schema() bigquery.Schema
+	TotalRows() uint64
+	Next(interface{}) error
+	PageInfo() *iterator.PageInfo
+
+	embedToIncludeNewMethods()
+}
+
+type Table interface {
+	CopierFrom(...Table) Copier
+	Create(context.Context, *bigquery.TableMetadata) error
+	DatasetID() string
+	Delete(context.Context) error
+	ExtractorTo(dst *bigquery.GCSReference) Extractor
+	FullyQualifiedName() string
+	LoaderFrom(bigquery.LoadSource) Loader
+	Metadata(context.Context) (*bigquery.TableMetadata, error)
+	ProjectID() string
+	Read(ctx context.Context) RowIterator
+	TableID() string
+	Update(context.Context, bigquery.TableMetadataToUpdate, string) (*bigquery.TableMetadata, error)
+	Uploader() Uploader
+
+	embedToIncludeNewMethods()
+}
+
+type TableIterator interface {
+	Next() (Table, error)
+	PageInfo() *iterator.PageInfo
+
+	embedToIncludeNewMethods()
+}
+
+type Uploader interface {
+	SetSkipInvalidRows(bool)
+	SetIgnoreUnknownValues(bool)
+	SetTableTemplateSuffix(string)
+	Put(context.Context, interface{}) error
+
+	embedToIncludeNewMethods()
+}

--- a/bigquery/bqiface/structs.go
+++ b/bigquery/bqiface/structs.go
@@ -1,0 +1,55 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bqiface
+
+import (
+	"cloud.google.com/go/bigquery"
+)
+
+type AccessEntry struct {
+	bigquery.AccessEntry
+	View Table // shadows bigquery.AccessEntry's field
+}
+
+type CopyConfig struct {
+	bigquery.CopyConfig
+	Srcs []Table // shadows bigquery.CopyConfig's field
+	Dst  Table   // shadows bigquery.CopyConfig's field
+}
+
+type DatasetMetadata struct {
+	bigquery.DatasetMetadata
+	Access []*AccessEntry // shadows bigquery.DatasetMetadata's field
+}
+
+type DatasetMetadataToUpdate struct {
+	bigquery.DatasetMetadataToUpdate
+	Access []*AccessEntry // shadows bigquery.DatasetMetadataToUpdate's field
+}
+
+type ExtractConfig struct {
+	bigquery.ExtractConfig
+	Src Table // shadows bigquery.ExtractConfig's field
+}
+
+type LoadConfig struct {
+	bigquery.LoadConfig
+	Dst Table // shadows bigquery.LoadConfig's field
+}
+
+type QueryConfig struct {
+	bigquery.QueryConfig
+	Dst Table // shaodws bigquery.QueryConfig's field
+}


### PR DESCRIPTION
This package is just like the stiface package, only for cloud.google.com/go/bigquery.

Writing this package turned out to be considerably more complex than
stiface.

Several structs in the bigquery package, like DatasetMetadata, were
almost usable directly except for one or two fields, so I wrote
bqiface structs that embedded the bigquery versions and shadowed the
problematic fields.