### PR TITLE
Allow nil QueryConfig.Dst

### DIFF
--- a/bigquery/bqiface/adapters.go
+++ b/bigquery/bqiface/adapters.go
@@ -190,7 +190,9 @@ func (q query) Read(ctx context.Context) (RowIterator, error) {
 
 func (q query) SetQueryConfig(c QueryConfig) {
 	q.Query.QueryConfig = c.QueryConfig
-	q.Query.QueryConfig.Dst = c.Dst.(table).Table
+	if c.Dst != nil {
+		q.Query.QueryConfig.Dst = c.Dst.(table).Table
+	}
 }
 
 func (r rowIterator) SetStartIndex(i uint64)     { r.RowIterator.StartIndex = i }


### PR DESCRIPTION
Some queries do not require a destination table, so Dst should be allowed to be nil.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-go-testing/5)
<!-- Reviewable:end -->
